### PR TITLE
Use proper shell in launch script

### DIFF
--- a/src/main/scripts/mjprof
+++ b/src/main/scripts/mjprof
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/bin/bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 java -cp "$JAVA_HOME/lib/tools.jar:$DIR/mjprof-1.0.jar:$DIR/libs/*.jar:$DIR/plugins/*" -Dmacros.configFile=${DIR}/macros.properties com.performizeit.mjprof.MJProf $*


### PR DESCRIPTION
If one is using another shell than `bash` (i.e. zsh, fish, ...) when running
`./mjprof`, the command will fail with this error:

```
./mjprof1.0/mjprof: 2: ./mjprof1.0/mjprof: Bad substitution
```

This fix solves the issue by explicitely asking the executing shell to be an
instance of `bash`.